### PR TITLE
Delay chess clock start until first move

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -165,6 +165,9 @@ export function startNewGame({ minutes, increment } = DEFAULT_TIME) {
   const minutesVal = Number.isFinite(minutes) ? minutes : DEFAULT_TIME.minutes;
   const incrementVal = Number.isFinite(increment) ? increment : DEFAULT_TIME.increment;
 
+  stopTimer();
+  state.timerId = null;
+
   state.timeControl = { minutes: minutesVal, increment: incrementVal };
   state.whiteTime = minutesVal * 60 * 1000;
   state.blackTime = minutesVal * 60 * 1000;
@@ -173,7 +176,7 @@ export function startNewGame({ minutes, increment } = DEFAULT_TIME) {
   state.lastMove = null;
   state.game.reset();
   state.gameOver = false;
-  startTimer();
+  state.lastTick = null;
 
   notifyMove(null, { type: 'reset' });
 }
@@ -213,7 +216,11 @@ function attemptMove(from, to, { promotion } = {}) {
   const status = evaluateGameEnd(move);
 
   if (!state.gameOver) {
-    startTimer();
+    if (!state.timerId) {
+      startTimer();
+    } else {
+      state.lastTick = Date.now();
+    }
   }
 
   notifyMove(move, { type: status || 'move' });


### PR DESCRIPTION
## Summary
- keep the game clock idle after a reset by clearing timer state instead of starting it immediately
- trigger the first timer start only after the first successful move and refresh the timestamp on later moves
- send a reset notification so the UI refreshes the visible clock values after a new game

## Testing
- yarn build *(fails: workspace package missing from lockfile because dependencies are not installed in this environment)*
- yarn install *(fails: registry access blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6907fc0dbb14832d87de4468e4988d5e