### PR TITLE
Reset highlights when selecting opponent pieces

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -204,6 +204,14 @@ function handleSquareClick(square) {
     state.selectedSquare = square;
     computeMoves(square);
   } else {
+    if (piece && piece.color !== game.turn()) {
+      state.customHighlights.clear();
+      state.engineHighlights = [];
+      ui.updateEngineLines([]);
+      if (boardController && typeof boardController.clearArrows === "function") {
+        boardController.clearArrows();
+      }
+    }
     clearSelection();
   }
   renderBoard();


### PR DESCRIPTION
## Summary
- clear user highlights and engine lines when clicking an opponent piece
- clear user arrows if available and sync engine panel when highlights reset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907fe172e88832db4450e4ecae21e4a