### PR TITLE
Fix board square parity for correct light and dark alignment

### DIFF
--- a/src/board.js
+++ b/src/board.js
@@ -567,7 +567,7 @@ export function createBoard(
     for (let file = 0; file < 8; file += 1) {
       const squareName = algebraicAt(file, rank);
       const squareEl = document.createElement("div");
-      squareEl.className = `square ${(rank + file) % 2 === 0 ? "dark" : "light"}`;
+      squareEl.className = `square ${(rank + file) % 2 === 0 ? "light" : "dark"}`;
       squareEl.dataset.square = squareName;
 
       const img = document.createElement("img");


### PR DESCRIPTION
## Summary
- swap the square parity in the board creator so even (rank + file) indices use the light class
- ensure the generated grid aligns d1 with a light square and d8 with a dark square

## Testing
- Tests not run (environment lacks npm registry access)


------
https://chatgpt.com/codex/tasks/task_e_69080018d2a4832d9adbae2b0769951d