### PR TITLE
Enhance engine overlay rendering options

### DIFF
--- a/src/board.js
+++ b/src/board.js
@@ -44,6 +44,7 @@ const boardState = {
   arrowLayer: null,
   arrowPreview: null,
   arrows: new Map(),
+  engineArrows: [],
   arrowDrag: null,
   listenersBound: false,
 };
@@ -308,6 +309,15 @@ function ensureArrowPreview() {
   return path;
 }
 
+function setEngineArrows(arrows) {
+  if (!Array.isArray(arrows)) {
+    boardState.engineArrows = [];
+  } else {
+    boardState.engineArrows = arrows;
+  }
+  renderArrows();
+}
+
 function removeArrow(key) {
   if (!boardState.arrows.has(key)) return;
   boardState.arrows.delete(key);
@@ -318,6 +328,28 @@ function renderArrows() {
   const layer = ensureArrowLayer();
   if (!layer) return;
   layer.querySelectorAll("[data-arrow-line]").forEach((node) => node.remove());
+  const preview = boardState.arrowPreview;
+  if (preview && preview.parentElement) {
+    preview.parentElement.removeChild(preview);
+  }
+
+  boardState.engineArrows.forEach((arrow, index) => {
+    const pathData = buildArrowPath(arrow.from, arrow.to);
+    if (!pathData) return;
+    const rank = Math.min(Math.max(Number.parseInt(arrow.rank, 10) || index + 1, 1), 3);
+    const path = document.createElementNS(SVG_NS, "path");
+    path.dataset.arrowLine = `engine-${index}`;
+    path.classList.add("board-arrow", "engine-arrow", `engine-arrow-${rank}`);
+    path.setAttribute("d", pathData);
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke-width", ARROW_THICKNESS);
+    path.setAttribute("stroke-linecap", "butt");
+    path.setAttribute("stroke-linejoin", "round");
+    path.setAttribute("marker-end", `url(#${ARROW_HEAD_ID})`);
+    path.setAttribute("pointer-events", "none");
+    layer.appendChild(path);
+  });
+
   boardState.arrows.forEach((arrow, key) => {
     const pathData = buildArrowPath(arrow.from, arrow.to);
     if (!pathData) return;
@@ -646,16 +678,54 @@ export function renderPosition(game, options = {}) {
     lastMove = null,
     customHighlights = [],
     engineHighlights = [],
+    engineDisplayMode = "both",
   } = options;
 
   const legalSet = new Set(legalMoves);
   const captureSet = new Set(captureMoves);
   const customSet = new Set(customHighlights);
 
-  const engineMap = new Map();
-  engineHighlights.forEach((square, index) => {
-    engineMap.set(square, index + 1);
+  const normalizedHighlights = Array.isArray(engineHighlights)
+    ? engineHighlights
+        .map((entry, index) => ({
+          from: entry?.from,
+          to: entry?.to,
+          rank: Number.isFinite(entry?.rank)
+            ? entry.rank
+            : Number.parseInt(entry?.rank, 10) || index + 1,
+        }))
+        .filter((entry) => entry.from || entry.to)
+    : [];
+
+  const showEngineSquares =
+    engineDisplayMode === "both" || engineDisplayMode === "squares";
+  const showEngineArrows =
+    engineDisplayMode === "both" || engineDisplayMode === "arrows";
+
+  const engineSquareMap = new Map();
+  const engineArrows = [];
+
+  normalizedHighlights.forEach((entry, index) => {
+    const rank = Math.min(Math.max(Number.parseInt(entry.rank, 10) || index + 1, 1), 3);
+    if (showEngineSquares) {
+      [entry.from, entry.to].forEach((square) => {
+        if (!square) return;
+        const existing = engineSquareMap.get(square);
+        if (!existing || rank < existing) {
+          engineSquareMap.set(square, rank);
+        }
+      });
+    }
+    if (showEngineArrows && entry.from && entry.to) {
+      engineArrows.push({ from: entry.from, to: entry.to, rank });
+    }
   });
+
+  if (showEngineArrows) {
+    setEngineArrows(engineArrows);
+  } else {
+    setEngineArrows([]);
+  }
 
   const boardMatrix = game.board();
   for (let rank = 0; rank < 8; rank += 1) {
@@ -703,8 +773,10 @@ export function renderPosition(game, options = {}) {
       if (customSet.has(squareName)) {
         squareEl.classList.add("user-highlight");
       }
-      if (engineMap.has(squareName)) {
-        squareEl.classList.add(`engine-move-${engineMap.get(squareName)}`);
+      if (engineSquareMap.has(squareName)) {
+        squareEl.classList.add(
+          `engine-move-${engineSquareMap.get(squareName)}`
+        );
       }
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ const state = {
   customHighlights: new Set(),
   lastMove: null,
   engineHighlights: [],
+  engineDisplayMode: "both",
   engineBusy: false,
   boardLocked: false,
 };
@@ -60,6 +61,7 @@ function renderBoard() {
     lastMove: state.lastMove,
     customHighlights: Array.from(state.customHighlights),
     engineHighlights: state.engineHighlights,
+    engineDisplayMode: state.engineDisplayMode,
   });
 }
 
@@ -264,7 +266,11 @@ function startAnalysis({ depth }) {
         ui.updateEngineLines([]);
       } else {
         ui.updateEngineLines(lines);
-        state.engineHighlights = lines.map((line) => line.to);
+        state.engineHighlights = lines.map((line, index) => ({
+          from: line.from,
+          to: line.to,
+          rank: index + 1,
+        }));
         renderBoard();
       }
     })
@@ -311,7 +317,15 @@ function initialize() {
     onRevealEnginePanel: () => {
       ui.showMessage("success", "Engine panel unlocked!");
     },
+    onEngineOverlayModeChange: (mode) => {
+      state.engineDisplayMode = mode;
+      renderBoard();
+    },
   });
+
+  if (typeof ui.setEngineOverlayMode === "function") {
+    ui.setEngineOverlayMode(state.engineDisplayMode);
+  }
 
   const boardElement = ui.getBoardElement();
   const controller = createBoard(boardElement, {

--- a/src/styles.css
+++ b/src/styles.css
@@ -537,6 +537,22 @@ h1,
   opacity: 0.75;
 }
 
+.board-arrow.engine-arrow {
+  opacity: 0.95;
+}
+
+.board-arrow.engine-arrow-1 {
+  stroke: rgba(59, 130, 246, 0.95);
+}
+
+.board-arrow.engine-arrow-2 {
+  stroke: rgba(16, 185, 129, 0.95);
+}
+
+.board-arrow.engine-arrow-3 {
+  stroke: rgba(244, 114, 182, 0.95);
+}
+
 .square.selected::after,
 .square.last-move::after,
 .square.legal-move-hint::after,
@@ -615,6 +631,28 @@ h1,
   flex-direction: column;
   gap: 16px;
   box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.engine-overlay-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.engine-overlay-label {
+  font-size: 0.85rem;
+  color: #dcdcdc;
+}
+
+.engine-overlay-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.engine-overlay-button {
+  min-width: 96px;
 }
 
 .engine-depth-control {

--- a/src/ui.js
+++ b/src/ui.js
@@ -374,6 +374,32 @@ export function initUI(rootEl, handlers = {}) {
             <button id="start-analysis" type="button" class="button button-accent">Start Analysis</button>
             <button id="stop-analysis" type="button" class="button button-danger">Stop</button>
           </div>
+          <div class="engine-overlay-controls" id="engine-overlay-controls">
+            <span class="engine-overlay-label">Overlay:</span>
+            <div class="engine-overlay-buttons" role="group" aria-label="Engine overlays">
+              <button
+                type="button"
+                class="button button-outline button-small engine-overlay-button"
+                data-engine-overlay-mode="squares"
+              >
+                Squares
+              </button>
+              <button
+                type="button"
+                class="button button-outline button-small engine-overlay-button"
+                data-engine-overlay-mode="arrows"
+              >
+                Arrows
+              </button>
+              <button
+                type="button"
+                class="button button-outline button-small engine-overlay-button"
+                data-engine-overlay-mode="both"
+              >
+                Both
+              </button>
+            </div>
+          </div>
           <div class="engine-lines" id="engine-lines"></div>
         </div>
       </section>
@@ -432,6 +458,7 @@ export function initUI(rootEl, handlers = {}) {
   }
 
   let currentTimeControl = { minutes: 5, increment: 0 };
+  let engineOverlayMode = 'both';
   let selectedPresetButton = null;
 
   timePresets.forEach((preset) => {
@@ -481,6 +508,9 @@ export function initUI(rootEl, handlers = {}) {
   const enginePanel = rootEl.querySelector('#engine-panel');
   const engineDepth = rootEl.querySelector('#engine-depth');
   const engineDepthValue = rootEl.querySelector('#engine-depth-value');
+  const engineOverlayButtons = Array.from(
+    rootEl.querySelectorAll('[data-engine-overlay-mode]')
+  );
   const startAnalysisBtn = rootEl.querySelector('#start-analysis');
   const stopAnalysisBtn = rootEl.querySelector('#stop-analysis');
   const engineLinesEl = rootEl.querySelector('#engine-lines');
@@ -491,6 +521,38 @@ export function initUI(rootEl, handlers = {}) {
   applyAppearance();
   clearEnginePanel(engineLinesEl);
   stopAnalysisBtn.disabled = true;
+
+  function updateEngineOverlayButtons(mode) {
+    if (!mode) return;
+    engineOverlayMode = mode;
+    engineOverlayButtons.forEach((button) => {
+      const value = button.dataset.engineOverlayMode;
+      const isActive = value === mode;
+      button.classList.toggle('active', isActive);
+      if (isActive) {
+        button.classList.add('button-accent');
+        button.classList.remove('button-outline');
+      } else {
+        button.classList.add('button-outline');
+        button.classList.remove('button-accent');
+      }
+    });
+  }
+
+  updateEngineOverlayButtons(engineOverlayMode);
+
+  engineOverlayButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.engineOverlayMode;
+      if (!mode || mode === engineOverlayMode) {
+        return;
+      }
+      updateEngineOverlayButtons(mode);
+      if (typeof handlers.onEngineOverlayModeChange === 'function') {
+        handlers.onEngineOverlayModeChange(mode);
+      }
+    });
+  });
 
   const matchTitleEl = rootEl.querySelector('#match-title');
   const matchEventEl = rootEl.querySelector('#match-event');
@@ -687,6 +749,9 @@ export function initUI(rootEl, handlers = {}) {
     },
     hideEnginePanel() {
       enginePanel.classList.add('hidden');
+    },
+    setEngineOverlayMode(mode) {
+      updateEngineOverlayButtons(mode);
     },
     getCurrentTimeControl() {
       return { ...currentTimeControl };


### PR DESCRIPTION
## Summary
- track engine suggestions as from/to pairs and store the current overlay display mode
- render engine-highlighted squares and ranked arrows based on the selected overlay preferences
- add UI controls and styles to toggle engine overlays between squares, arrows, or both

## Testing
- yarn build *(fails: workspace missing from lockfile without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690805356a34832db20fd0a93e9e1747