### PR TITLE
Add notation import controls for PGN and FEN

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -17,6 +17,16 @@ const state = {
   timeControl: { ...DEFAULT_TIME }
 };
 
+function getTimeControlSettings() {
+  const minutes = Number.isFinite(state.timeControl?.minutes)
+    ? state.timeControl.minutes
+    : DEFAULT_TIME.minutes;
+  const increment = Number.isFinite(state.timeControl?.increment)
+    ? state.timeControl.increment
+    : DEFAULT_TIME.increment;
+  return { minutes, increment };
+}
+
 function stopTimer() {
   if (state.timerId) {
     clearInterval(state.timerId);
@@ -179,6 +189,67 @@ export function startNewGame({ minutes, increment } = DEFAULT_TIME) {
   state.lastTick = null;
 
   notifyMove(null, { type: 'reset' });
+}
+
+function resetAfterExternalLoad() {
+  stopTimer();
+  state.timerId = null;
+  state.lastTick = null;
+  const { minutes, increment } = getTimeControlSettings();
+  state.whiteTime = minutes * 60 * 1000;
+  state.blackTime = minutes * 60 * 1000;
+  state.incrementMs = increment * 1000;
+  state.lastMove = null;
+  state.activeColor = state.game.turn();
+  state.gameOver = state.game.isGameOver();
+}
+
+export function loadFen(fen) {
+  if (typeof fen !== 'string' || fen.trim() === '') {
+    return { success: false, message: 'FEN string is empty.' };
+  }
+
+  const trimmedFen = fen.trim();
+  const newGame = new Chess();
+  let loaded = false;
+  try {
+    loaded = newGame.load(trimmedFen);
+  } catch (error) {
+    loaded = false;
+  }
+
+  if (!loaded) {
+    return { success: false, message: 'Unable to load FEN.' };
+  }
+
+  state.game = newGame;
+  resetAfterExternalLoad();
+  notifyMove(null, { type: 'load', source: 'fen' });
+  return { success: true };
+}
+
+export function loadPgn(pgn) {
+  if (typeof pgn !== 'string' || pgn.trim() === '') {
+    return { success: false, message: 'PGN string is empty.' };
+  }
+
+  const trimmedPgn = pgn.trim();
+  const newGame = new Chess();
+  let loaded = false;
+  try {
+    loaded = newGame.loadPgn(trimmedPgn, { sloppy: true });
+  } catch (error) {
+    loaded = false;
+  }
+
+  if (!loaded) {
+    return { success: false, message: 'Unable to load PGN.' };
+  }
+
+  state.game = newGame;
+  resetAfterExternalLoad();
+  notifyMove(null, { type: 'load', source: 'pgn' });
+  return { success: true };
 }
 
 function attemptMove(from, to, { promotion } = {}) {

--- a/src/game.js
+++ b/src/game.js
@@ -191,7 +191,7 @@ export function startNewGame({ minutes, increment } = DEFAULT_TIME) {
   notifyMove(null, { type: 'reset' });
 }
 
-function resetAfterExternalLoad() {
+function resetAfterExternalLoad({ lastMove } = {}) {
   stopTimer();
   state.timerId = null;
   state.lastTick = null;
@@ -199,7 +199,7 @@ function resetAfterExternalLoad() {
   state.whiteTime = minutes * 60 * 1000;
   state.blackTime = minutes * 60 * 1000;
   state.incrementMs = increment * 1000;
-  state.lastMove = null;
+  state.lastMove = lastMove || null;
   state.activeColor = state.game.turn();
   state.gameOver = state.game.isGameOver();
 }
@@ -211,15 +211,11 @@ export function loadFen(fen) {
 
   const trimmedFen = fen.trim();
   const newGame = new Chess();
-  let loaded = false;
   try {
-    loaded = newGame.load(trimmedFen);
+    newGame.load(trimmedFen);
   } catch (error) {
-    loaded = false;
-  }
-
-  if (!loaded) {
-    return { success: false, message: 'Unable to load FEN.' };
+    const message = error instanceof Error ? error.message : 'Unable to load FEN.';
+    return { success: false, message };
   }
 
   state.game = newGame;
@@ -235,20 +231,21 @@ export function loadPgn(pgn) {
 
   const trimmedPgn = pgn.trim();
   const newGame = new Chess();
-  let loaded = false;
+  let lastMove = null;
   try {
-    loaded = newGame.loadPgn(trimmedPgn, { sloppy: true });
+    newGame.loadPgn(trimmedPgn);
+    const history = newGame.history({ verbose: true });
+    if (history.length > 0) {
+      lastMove = history[history.length - 1];
+    }
   } catch (error) {
-    loaded = false;
-  }
-
-  if (!loaded) {
-    return { success: false, message: 'Unable to load PGN.' };
+    const message = error instanceof Error ? error.message : 'Unable to load PGN.';
+    return { success: false, message };
   }
 
   state.game = newGame;
-  resetAfterExternalLoad();
-  notifyMove(null, { type: 'load', source: 'pgn' });
+  resetAfterExternalLoad({ lastMove });
+  notifyMove(lastMove, { type: 'load', source: 'pgn' });
   return { success: true };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ import {
   getPgn,
   getClocks,
   getTimeControl,
+  loadFen,
+  loadPgn,
 } from "./game.js";
 import { createBoard, renderPosition } from "./board.js";
 import { initEngine, analyze, stop as stopEngine } from "./engine.js";
@@ -135,6 +137,12 @@ function handleMove(event) {
     }
     refreshMatchDetails();
     ui.showMessage("info", "New game started.");
+    boardController.setInteractive(true);
+    state.boardLocked = false;
+  } else if (status?.type === "load") {
+    if (boardController && typeof boardController.clearArrows === "function") {
+      boardController.clearArrows();
+    }
     boardController.setInteractive(true);
     state.boardLocked = false;
   }
@@ -312,6 +320,24 @@ function initialize() {
     },
     onCopyFen: () => getFen(),
     onCopyPgn: () => getPgn(),
+    onSetFen: (fen) => {
+      stopAnalysis({ quiet: true });
+      const result = loadFen(fen);
+      if (result.success) {
+        state.engineHighlights = [];
+        ui.updateEngineLines([]);
+      }
+      return result;
+    },
+    onSetPgn: (pgn) => {
+      stopAnalysis({ quiet: true });
+      const result = loadPgn(pgn);
+      if (result.success) {
+        state.engineHighlights = [];
+        ui.updateEngineLines([]);
+      }
+      return result;
+    },
     onStartAnalysis: ({ depth }) => startAnalysis({ depth }),
     onStopAnalysis: () => stopAnalysis({ quiet: true }),
     onRevealEnginePanel: () => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -422,10 +422,14 @@ export function initUI(rootEl, handlers = {}) {
             <div id="move-list" class="move-list"></div>
             <div class="button-row">
               <button id="copy-pgn" type="button" class="button button-muted">Copy PGN</button>
-              <button id="copy-fen" type="button" class="button button-muted">Copy FEN</button>
+              <button id="load-pgn" type="button" class="button button-muted">Load PGN</button>
             </div>
-            <textarea id="pgn-output" rows="4" readonly placeholder="PGN will appear here" class="notation-output"></textarea>
-            <textarea id="fen-output" rows="2" readonly placeholder="FEN will appear here" class="notation-output"></textarea>
+            <div class="button-row">
+              <button id="copy-fen" type="button" class="button button-muted">Copy FEN</button>
+              <button id="load-fen" type="button" class="button button-muted">Load FEN</button>
+            </div>
+            <textarea id="pgn-output" rows="4" placeholder="PGN will appear here" class="notation-output"></textarea>
+            <textarea id="fen-output" rows="2" placeholder="FEN will appear here" class="notation-output"></textarea>
           </div>
         </div>
       </section>
@@ -501,7 +505,9 @@ export function initUI(rootEl, handlers = {}) {
   const appearanceGridLeft = rootEl.querySelector('#appearance-grid-left');
   const appearanceGridRight = rootEl.querySelector('#appearance-grid-right');
   const copyFenBtn = rootEl.querySelector('#copy-fen');
+  const loadFenBtn = rootEl.querySelector('#load-fen');
   const copyPgnBtn = rootEl.querySelector('#copy-pgn');
+  const loadPgnBtn = rootEl.querySelector('#load-pgn');
   const pgnOutput = rootEl.querySelector('#pgn-output');
   const fenOutput = rootEl.querySelector('#fen-output');
   const cheatText = rootEl.querySelector('#cheatcode-text');
@@ -639,6 +645,42 @@ export function initUI(rootEl, handlers = {}) {
     button.addEventListener('click', resetAppearance);
   });
 
+  function interpretHandlerResult(result) {
+    if (typeof result === 'boolean') {
+      return { success: result };
+    }
+    if (result && typeof result === 'object') {
+      if (Object.prototype.hasOwnProperty.call(result, 'success')) {
+        return { success: Boolean(result.success), message: result.message };
+      }
+      if (Object.prototype.hasOwnProperty.call(result, 'error')) {
+        return { success: false, message: result.error };
+      }
+    }
+    return { success: Boolean(result) };
+  }
+
+  async function handleNotationLoad({ textarea, handler, emptyMessage, successMessage, invalidMessage }) {
+    if (!handler || !textarea) return;
+    const value = textarea.value.trim();
+    textarea.value = value;
+    if (!value) {
+      messageApi.show('error', emptyMessage);
+      return;
+    }
+    try {
+      const result = interpretHandlerResult(await Promise.resolve(handler(value)));
+      if (result.success) {
+        messageApi.show('success', result.message || successMessage);
+      } else {
+        messageApi.show('error', result.message || invalidMessage);
+      }
+    } catch (error) {
+      const fallbackMessage = error && typeof error.message === 'string' ? error.message : invalidMessage;
+      messageApi.show('error', fallbackMessage || invalidMessage);
+    }
+  }
+
   copyFenBtn.addEventListener('click', async () => {
     if (!handlers.onCopyFen) return;
     const fen = handlers.onCopyFen();
@@ -651,6 +693,18 @@ export function initUI(rootEl, handlers = {}) {
     }
   });
 
+  if (loadFenBtn) {
+    loadFenBtn.addEventListener('click', () => {
+      handleNotationLoad({
+        textarea: fenOutput,
+        handler: handlers.onSetFen,
+        emptyMessage: 'Enter a FEN string to load.',
+        successMessage: 'FEN loaded successfully.',
+        invalidMessage: 'Invalid FEN string.'
+      });
+    });
+  }
+
   copyPgnBtn.addEventListener('click', async () => {
     if (!handlers.onCopyPgn) return;
     const pgn = handlers.onCopyPgn();
@@ -662,6 +716,18 @@ export function initUI(rootEl, handlers = {}) {
       messageApi.show('error', 'Unable to copy PGN.');
     }
   });
+
+  if (loadPgnBtn) {
+    loadPgnBtn.addEventListener('click', () => {
+      handleNotationLoad({
+        textarea: pgnOutput,
+        handler: handlers.onSetPgn,
+        emptyMessage: 'Enter a PGN string to load.',
+        successMessage: 'PGN loaded successfully.',
+        invalidMessage: 'Invalid PGN data.'
+      });
+    });
+  }
 
   engineDepth.addEventListener('input', () => {
     engineDepthValue.textContent = engineDepth.value;


### PR DESCRIPTION
## Summary
- add load buttons next to the existing PGN/FEN copy controls and surface feedback through the UI message API
- expose handlers from the UI to trigger PGN/FEN loading and clear stale engine overlays when imports succeed
- implement Chess.js-backed loaders that reset clocks and notify listeners so the board and notation stay in sync

## Testing
- npm run build *(fails: vite is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908082d2088832d94ecb43ccf891ba9